### PR TITLE
Use snapshots for testing regexes

### DIFF
--- a/__snapshots__/jouter.test.js.snap
+++ b/__snapshots__/jouter.test.js.snap
@@ -1,0 +1,7 @@
+exports[`routeRe will convert tokens to regexp 1`] = `/^\/([^\/]+)\/drink-([^\/]+)$/`;
+
+exports[`routeRe will match prefix wildcards 1`] = `/^\/foo(\/.*)$/`;
+
+exports[`routeRe will match route as is if no tokens 1`] = `/^\/about$/`;
+
+exports[`routeRe will match wildcard 1`] = `/^\/foo\/.*$/`;

--- a/jouter.test.js
+++ b/jouter.test.js
@@ -1,16 +1,16 @@
-import {routeRe, route, createRouter} from './jouter'
+import { routeRe, route, createRouter } from './jouter'
 
 describe('routeRe', () => {
   test('will convert tokens to regexp', () => {
-    expect(routeRe('/:foo/drink-:bar')).toEqual(/^\/([^\/]+)\/drink-([^\/]+)$/)
+    expect(routeRe('/:foo/drink-:bar')).toMatchSnapshot()
   })
 
   test('will match route as is if no tokens', () => {
-    expect(routeRe('/about')).toEqual(/^\/about$/)
+    expect(routeRe('/about')).toMatchSnapshot()
   })
 
   test('will match wildcard', () => {
-    expect(routeRe('/foo/*')).toEqual(/^\/foo\/.*$/)
+    expect(routeRe('/foo/*')).toMatchSnapshot()
   })
 
   test('will return regexp as is if passed one', () => {
@@ -24,7 +24,7 @@ describe('routeRe', () => {
   })
 
   test('will match prefix wildcards', () => {
-    expect(routeRe('/foo/...')).toEqual(/^\/foo(\/.*)$/)
+    expect(routeRe('/foo/...')).toMatchSnapshot()
   })
 })
 


### PR DESCRIPTION
This commit changes the unit tests such that regexps are defined using snapshot fixtures.