### PR TITLE
[Backwards-incompatible] Event handling changes

### DIFF
--- a/jouter.js
+++ b/jouter.js
@@ -68,7 +68,6 @@ export const createRouter = (myPathHandler = {}) => {
   }
 
   const handleEvent = e => {
-    console.log('called')
     e.preventDefault()
     const target = e.currentTarget
     go(target.href, target.title)

--- a/jouter.js
+++ b/jouter.js
@@ -68,8 +68,10 @@ export const createRouter = (myPathHandler = {}) => {
   }
 
   const handleEvent = e => {
+    console.log('called')
     e.preventDefault()
-    go(e.target.href, e.target.title)
+    const target = e.currentTarget
+    go(target.href, target.title)
   }
 
   const start = () => {

--- a/jouter.test.js
+++ b/jouter.test.js
@@ -62,6 +62,20 @@ describe('createRouter', () => {
     expect(currentPath).toBe('/baz')
   })
 
+  fit('handling events on nested objects', () => {
+    const router = createRouter(fakePathHandler)
+    const fn = jest.fn()
+    const elem = document.createElement('a')
+    elem.href = '/baz'
+    elem.innerHTML = '<span>click here</span>';
+    const nested = elem.querySelector('span');
+    router.add(fn, '/:x')
+    elem.addEventListener('click', router.handleEvent)
+    nested.dispatchEvent(new Event('click', {bubbles: true, cancelable: true}));
+    expect(fn).toHaveBeenCalledWith('baz')
+    expect(currentPath).toBe('/baz')
+  });
+
   test('router object is a function', () => {
     const router = createRouter(fakePathHandler)
     expect(router).toBeInstanceOf(Function)

--- a/jouter.test.js
+++ b/jouter.test.js
@@ -53,16 +53,11 @@ describe('createRouter', () => {
   test('handing events', () => {
     const router = createRouter(fakePathHandler)
     const fn = jest.fn()
-    const fakeEvent = {
-      preventDefault: jest.fn(),
-      target: {
-        href: '/baz',
-        title: 'Baz'
-      }
-    }
+    const elem = document.createElement('a')
+    elem.href = '/baz'
     router.add(fn, '/:x')
-    router.handleEvent(fakeEvent)
-    expect(fakeEvent.preventDefault).toHaveBeenCalled()
+    elem.addEventListener('click', router.handleEvent)
+    elem.dispatchEvent(new Event('click'));
     expect(fn).toHaveBeenCalledWith('baz')
     expect(currentPath).toBe('/baz')
   })

--- a/jouter.test.js
+++ b/jouter.test.js
@@ -62,7 +62,7 @@ describe('createRouter', () => {
     expect(currentPath).toBe('/baz')
   })
 
-  fit('handling events on nested objects', () => {
+  test('handling events on nested objects', () => {
     const router = createRouter(fakePathHandler)
     const fn = jest.fn()
     const elem = document.createElement('a')


### PR DESCRIPTION
This is a small change on the event handling code such that it is able to trap and handle events that are bubbling from the children. This is theoretically a backwards-incompatible changes since it changes the existing behavior, but I doubt anyone's been specifically depending on this behavior.